### PR TITLE
Fix `undefined` short circuit

### DIFF
--- a/src/components/BracketGenerator.tsx
+++ b/src/components/BracketGenerator.tsx
@@ -23,7 +23,7 @@ const makeFinals = ({ games }: { games: Game[] }): Array<{ game: Game, height: n
           isInGroup(id) &&
           _.any(
             sides,
-            ({ seed }) => seed !== null && seed.sourceGame !== null && seed.rank === 1 && seed.sourceGame.id === game.id
+            ({ seed }) => seed && seed.sourceGame !== null && seed.rank === 1 && seed.sourceGame.id === game.id
           )
         )
       )

--- a/src/components/BracketGenerator.tsx
+++ b/src/components/BracketGenerator.tsx
@@ -23,7 +23,7 @@ const makeFinals = ({ games }: { games: Game[] }): Array<{ game: Game, height: n
           isInGroup(id) &&
           _.any(
             sides,
-            ({ seed }) => seed && seed.sourceGame !== null && seed.rank === 1 && seed.sourceGame.id === game.id
+            ({ seed }) => seed && seed.sourceGame && seed.rank === 1 && seed.sourceGame.id === game.id
           )
         )
       )


### PR DESCRIPTION
If you don't have a `seed` in a team, then the `undefined` gets caught. Current implementation checks if `null` but doesn't check if it's undefined.

![image](https://user-images.githubusercontent.com/17035115/77108691-e5aa7b00-69df-11ea-8cba-67a3a1153996.png)
